### PR TITLE
Update demo to wait for Conjur

### DIFF
--- a/local/bin/2-load-secrets-into-conjur
+++ b/local/bin/2-load-secrets-into-conjur
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+# wait for Conjur to get admin api key
+docker-compose exec -T conjur conjurctl wait -r 30 -p 80
 api_key=$(docker-compose exec -T conjur bash -c 'rails r "puts Role[%Q{default:user:admin}].api_key" 2>/dev/null')
 
 # load policy

--- a/local/bin/4-install-service-broker
+++ b/local/bin/4-install-service-broker
@@ -13,11 +13,7 @@ pushd conjur-service-broker
 popd
 rm -rf conjur-service-broker*
 
-# wait for Conjur to get admin api key
-docker-compose exec -T conjur conjurctl wait -r 30 -p 80
 api_key=$(docker-compose exec -T conjur bash -c 'rails r "puts Role[%Q{default:user:admin}].api_key" 2>/dev/null')
-
-echo "API key: $api_key"
 
 # configuring the SB env
 cf set-env conjur-service-broker SECURITY_USER_NAME TEMPORARY


### PR DESCRIPTION
This is a small change that moves the `wait for Conjur` command to earlier in the set of scripts, before the first time Conjur policy is loaded. 