### PR TITLE
Conjur Demo is updated to remove `jq` dependency

### DIFF
--- a/local/bin/3-install-buildpacks
+++ b/local/bin/3-install-buildpacks
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # get the meta-buildpack and upload to cf
-curl -L $(curl -s https://api.github.com/repos/cf-platform-eng/meta-buildpack/releases/latest | jq -r ".zipball_url") > meta-buildpack.zip
+curl -L $(curl -s https://api.github.com/repos/cf-platform-eng/meta-buildpack/releases/latest | grep zipball_url | awk '{print $NF}' | sed 's/",*//g') > meta-buildpack.zip
 unzip meta-buildpack.zip
 repo_dir=$(ls | grep cf-platform-eng-meta-buildpack)
 mv $repo_dir meta-buildpack
@@ -13,7 +13,7 @@ popd
 rm -rf meta-buildpack*
 
 # get the Conjur buildpack and upload to cf
-curl -L $(curl -s https://api.github.com/repos/cyberark/cloudfoundry-conjur-buildpack/releases/latest | jq -r ".zipball_url") > cloudfoundry-conjur-buildpack.zip
+curl -L $(curl -s https://api.github.com/repos/cyberark/cloudfoundry-conjur-buildpack/releases/latest | grep zipball_url | awk '{print $NF}' | sed 's/",*//g') > cloudfoundry-conjur-buildpack.zip
 unzip cloudfoundry-conjur-buildpack.zip
 repo_dir=$(ls | grep cyberark-cloudfoundry-conjur-buildpack)
 mv $repo_dir cloudfoundry-conjur-buildpack

--- a/local/bin/4-install-service-broker
+++ b/local/bin/4-install-service-broker
@@ -2,7 +2,7 @@
 APP_NAME="hello-world"
 
 # get the Conjur service broker, upload to cf, and configure
-curl -L $(curl -s https://api.github.com/repos/cyberark/conjur-service-broker/releases/latest | jq -r ".zipball_url") > conjur-service-broker.zip
+curl -L $(curl -s https://api.github.com/repos/cyberark/conjur-service-broker/releases/latest | grep zipball_url | awk '{print $NF}' | sed 's/",*//g') > conjur-service-broker.zip
 unzip conjur-service-broker.zip
 repo_dir=$(ls | grep cyberark-conjur-service-broker)
 mv $repo_dir conjur-service-broker


### PR DESCRIPTION
This update uses `sed` instead of `jq` to get the URL for the dependent repo zip files.