### PR TITLE
Demo is updated to use the v1.0.0 release of the Conjur Buildpack

### DIFF
--- a/local/bin/3-install-buildpacks
+++ b/local/bin/3-install-buildpacks
@@ -13,12 +13,10 @@ popd
 rm -rf meta-buildpack*
 
 # get the Conjur buildpack and upload to cf
-curl -L $(curl -s https://api.github.com/repos/cyberark/cloudfoundry-conjur-buildpack/releases/latest | grep zipball_url | awk '{print $NF}' | sed 's/",*//g') > cloudfoundry-conjur-buildpack.zip
-unzip cloudfoundry-conjur-buildpack.zip
-repo_dir=$(ls | grep cyberark-cloudfoundry-conjur-buildpack)
-mv $repo_dir cloudfoundry-conjur-buildpack
-
-pushd cloudfoundry-conjur-buildpack
+mkdir conjur-buildpack
+pushd conjur-buildpack
+  curl -L $(curl -s https://api.github.com/repos/cyberark/cloudfoundry-conjur-buildpack/releases/latest | grep browser_download_url | grep zip | awk '{print $NF}' | sed 's/",*//g') > conjur-buildpack.zip
+  unzip conjur-buildpack.zip
   ./upload.sh
 popd
-rm -rf cloudfoundry-conjur-buildpack*
+rm -rf conjur-buildpack

--- a/local/bin/stop
+++ b/local/bin/stop
@@ -5,7 +5,7 @@ cf delete-service conjur -f || true
 cf delete-service-broker conjur-service-broker -f || true
 cf delete conjur-service-broker -f || true
 cf delete-buildpack meta_buildpack -f || true
-cf delete-buildpack cloudfoundry_conjur_buildpack -f || true
+cf delete-buildpack conjur_buildpack -f || true
 cf delete-space cyberark-conjur-demo -f || true
 cf delete-org cyberark -f || true
 


### PR DESCRIPTION
This PR updates the demo to grab the latest ZIP release of the Conjur Buildpack and upload the BP to CF using the `upload.sh` script in that ZIP file.