### PR TITLE
Clarify README and remove cf dev dep check

### DIFF
--- a/pcf-with-installed-tile/README.md
+++ b/pcf-with-installed-tile/README.md
@@ -35,8 +35,7 @@ conjur authn login
 Authenticate as the `admin` user for the Conjur instance (or another user who has authority to modify `root` policy) - this demo will need to update `root` policy to add the `pcf` policy namespace and the `pcf-admin` user / group.
 
 ## Running the demo
-Our demo script will be modifying Conjur policy to add the application host to a group with access to the application's secrets, so it will need access to Conjur account info. Since we have stored this info in the OSX keyring, we can run the [demo script](bin/start) by calling
-`summon -p keyring.py ./bin/start`.
+Our demo script will be modifying Conjur policy to add the application host to a group with access to the application's secrets, so it will need access to Conjur account info. Since we have stored this info in the OSX keyring, we can run the [demo script](bin/start) by calling `./bin/start` (for v4) or `summon -p keyring.py ./bin/start` (for v5).
 
 ### What the script does
 The start-up script clears out your workspace - it deletes any previously deployed `hello-world` apps in the demo space, removes the Conjur service, and removes the demo space.

--- a/pcf-with-installed-tile/bin/0-check-dependencies
+++ b/pcf-with-installed-tile/bin/0-check-dependencies
@@ -7,7 +7,6 @@ fatal () {
 }
 
 [[ -n `which cf` ]] || fatal "Cloud Foundry command line tool not found in \$PATH - read the README!"
-[[ `cf dev status | head -n1` -eq 'Running' ]] || cf dev start
 
 cur_dir=$(basename $(pwd))
 if [[ "$cur_dir" != "pcf-with-installed-tile" ]]


### PR DESCRIPTION
This PR updates the README to clarify the commands to run the demo for v4 vs v5, and removes a `cf dev` dependency check in the initial script.